### PR TITLE
Use a valid shift for SCRIPT_ENABLE_SIGHASH_FORKID

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -89,7 +89,7 @@ enum
     SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
 
     // Do we accept signature using SIGHASH_FORKID
-    SCRIPT_ENABLE_SIGHASH_FORKID = (1U << 42),
+    SCRIPT_ENABLE_SIGHASH_FORKID = (1U << 10),
 };
 
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);


### PR DESCRIPTION
I chose a large number for this because the ZCL codebase is so old that there have been many newer enums put there upstream, but 42 wont fit in the datatype, so just use the next valid value. I doubt y'all gonna merge signature hash changes from BTC or ZEC anytime soon
  