### PR TITLE
strMessageMagic for BitcoinPrivate

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ static void CheckBlockIndex();
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
 
-const string strMessageMagic = "Zcash Signed Message:\n";
+const string strMessageMagic = "BitcoinPrivate Signed Message:\n";
 
 // Internal stuff
 namespace {


### PR DESCRIPTION
This would be part of a 'hard fork' technically, and would allow us to keep messages from our chain unique/distinct and identifiable. See my original post: https://github.com/z-classic/zclassic/issues/135