### PR TITLE
SIGHASH_FORKID defined as an int but used in the code as a bit-field constant

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -28,7 +28,7 @@ enum
     SIGHASH_ALL          = 1,
     SIGHASH_NONE         = 2,
     SIGHASH_SINGLE       = 3,
-    SIGHASH_FORKID       = 0x42,
+    SIGHASH_FORKID       = 0x40,
     SIGHASH_ANYONECANPAY = 0x80,
 };
 


### PR DESCRIPTION
This is a serious error which is causing a lot of trouble in the test
suite. I have not been able to determine what sorts of problems it
might cause, or vulnerabilities open up, but I believe that this
constant should be changed asap.