### PR TITLE
cross compiling for windows fix, and detailed build instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ sudo apt-get install \
 2. Set the default ming32 gcc/g++ compiler option to posix, fix problem with packages in Xenial
 
 ```{r, engine='bash'}
-sudo apt install software-properties-common
-sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu zesty universe"
-sudo apt update
-sudo apt upgrade
 sudo update-alternatives --config x86_64-w64-mingw32-gcc
 sudo update-alternatives --config x86_64-w64-mingw32-g++
 ```

--- a/README.md
+++ b/README.md
@@ -35,20 +35,63 @@ Install:
 ```
 
 ### Windows
-Get dependencies:
+There are two proven ways to build BTCP for Windows:
+
+* On Linux using [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Ubuntu 16.04 Xenial is proven to work and the instructions is for such release.
+* On Windows 10 (64-bit version) using [Windows Subsystem for Linux (WSL)](https://msdn.microsoft.com/commandline/wsl/about) and Mingw-w64 cross compiler tool chain.
+
+With Windows 10, Microsoft released a feature called WSL. It basically allows you to run a bash shell directly on Windows in an ubuntu environment. WSL can be installed with other Linux variants, but as mentioned before, the distro proven to work is Ubuntu.
+Follow this [link](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) for installing WSL first
+
+### Building for Windows 64-Bit
+1. Get the usual dependencies:
 ```{r, engine='bash'}
 sudo apt-get install \
       build-essential pkg-config libc6-dev m4 g++-multilib \
       autoconf libtool ncurses-dev unzip git python \
-      zlib1g-dev wget bsdmainutils automake mingw-w64
+      zlib1g-dev wget bsdmainutils automake
 ```
 
-Install (Cross-Compiled, building on Windows is not supported yet):
+2. Set the default ming32 gcc/g++ compiler option to posix
+
 ```{r, engine='bash'}
-# Build
+sudo apt install mingw-w64
+sudo update-alternatives --config x86_64-w64-mingw32-gcc
+sudo update-alternatives --config x86_64-w64-mingw32-g++
+```
+
+3. Install Rust
+```{r, engine='bash'}
+curl https://sh.rustup.rs -sSf | sh
+source ~/.cargo/env
+rustup install stable-x86_64-unknown-linux-gnu
+rustup install stable-x86_64-pc-windows-gnu
+rustup target add x86_64-pc-windows-gnu
+vi  ~/.cargo/config
+```
+and add:
+```
+[target.x86_64-pc-windows-gnu]
+linker = "/usr/bin/x86_64-w64-mingw32-gcc"
+```
+
+Note that in WSL, the BTCPrivate source code must be somewhere in the default mount file system. i.e /usr/src/BTCPrivate, and not on /mnt/d/. What this means is that you cannot build directly on the windows system
+
+4. Build for Windows
+
+```{r, engine='bash'}
+PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
 ./btcputil/build-win.sh -j$(nproc)
 ```
-The exe will save to `src` which you can then move to a windows machine
+
+5. Installation
+
+After building in WSL, you can make a copy of the compiled executables to a directory on your Windows file system. This is done the following way
+
+```{r, engine='bash'}
+make install DESTDIR=/mnt/c/btcp/BTCPrivate
+```
+This will install the executables to `c:\btcp\BTCPrivate
 
 ### Mac
 Get dependencies:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Install:
 ./src/btcpd
 ```
 
+### Additional notes
+
+If you plan to build for windows and linux at the same time, be sure to delete all the built files for whatever you build first. An easy way to do this is by taking the binaries out of the repo, delete all files except the .git folder and then do a git hard reset.
+
 About
 --------------
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Follow this [link](https://msdn.microsoft.com/en-us/commandline/wsl/install_guid
 sudo apt-get install \
       build-essential pkg-config libc6-dev m4 g++-multilib \
       autoconf libtool ncurses-dev unzip git python \
-      zlib1g-dev wget bsdmainutils automake
+      zlib1g-dev wget bsdmainutils automake mingw-w64
 ```
 
 2. Set the default ming32 gcc/g++ compiler option to posix

--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ sudo apt-get install \
       zlib1g-dev wget bsdmainutils automake mingw-w64
 ```
 
-2. Set the default ming32 gcc/g++ compiler option to posix
+2. Set the default ming32 gcc/g++ compiler option to posix, fix problem with packages in Xenial
 
 ```{r, engine='bash'}
-sudo apt install mingw-w64
+sudo apt install software-properties-common
+sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu zesty universe"
+sudo apt update
+sudo apt upgrade
 sudo update-alternatives --config x86_64-w64-mingw32-gcc
 sudo update-alternatives --config x86_64-w64-mingw32-g++
 ```

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -7,13 +7,17 @@ $(package)_sha256_hash=a5760a90d4a1045c8944204f29fa2a3cf2f800afee400f88bf89bbfe2
 $(package)_git_commit=91348647a86201a9482ad4ad68398152dc3d635e
 $(package)_dependencies=rust
 
+#  cargo build --release
 define $(package)_build_cmds
-  cargo build --release
+    cargo  build --release --lib --target="x86_64-pc-windows-gnu"
 endef
+
+#  cp target/release/librustzcash.a $($(package)_staging_dir)$(host_prefix)/lib/ && \
+#
 
 define $(package)_stage_cmds
   mkdir $($(package)_staging_dir)$(host_prefix)/lib/ && \
   mkdir $($(package)_staging_dir)$(host_prefix)/include/ && \
-  cp target/release/librustzcash.a $($(package)_staging_dir)$(host_prefix)/lib/ && \
+  cp target/x86_64-pc-windows-gnu/release/rustzcash.lib $($(package)_staging_dir)$(host_prefix)/lib/librustzcash.a && \
   cp include/librustzcash.h $($(package)_staging_dir)$(host_prefix)/include/
 endef

--- a/depends/packages/librustzcash.mk
+++ b/depends/packages/librustzcash.mk
@@ -6,18 +6,21 @@ $(package)_download_file=$($(package)_git_commit).tar.gz
 $(package)_sha256_hash=a5760a90d4a1045c8944204f29fa2a3cf2f800afee400f88bf89bbfe2cce1279
 $(package)_git_commit=91348647a86201a9482ad4ad68398152dc3d635e
 $(package)_dependencies=rust
+ifeq ($(host_os),mingw32)
+  rust_build=cargo build --release --lib --target="x86_64-pc-windows-gnu"
+  rust_target=target/x86_64-pc-windows-gnu/release/rustzcash.lib $($(package)_staging_dir)$(host_prefix)/lib/librustzcash.a
+else
+  rust_build=cargo build --release
+  rust_target=target/release/librustzcash.a $($(package)_staging_dir)$(host_prefix)/lib/
+endif
 
-#  cargo build --release
 define $(package)_build_cmds
-    cargo  build --release --lib --target="x86_64-pc-windows-gnu"
+  $(rust_build)
 endef
-
-#  cp target/release/librustzcash.a $($(package)_staging_dir)$(host_prefix)/lib/ && \
-#
 
 define $(package)_stage_cmds
   mkdir $($(package)_staging_dir)$(host_prefix)/lib/ && \
   mkdir $($(package)_staging_dir)$(host_prefix)/include/ && \
-  cp target/x86_64-pc-windows-gnu/release/rustzcash.lib $($(package)_staging_dir)$(host_prefix)/lib/librustzcash.a && \
+  cp $(rust_target) && \
   cp include/librustzcash.h $($(package)_staging_dir)$(host_prefix)/include/
 endef

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -2,7 +2,9 @@ package=rust
 $(package)_version=1.16.0
 $(package)_download_path=https://static.rust-lang.org/dist
 $(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
+$(package)_file_name=rust-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
 $(package)_sha256_hash_linux=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
+$(package)_sha256_hash=523cd248363afdc4e2c0e1f219607897b6925294a33154d7e67224addfd15eb0
 $(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
 $(package)_sha256_hash_darwin=2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926
 

--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -2,11 +2,11 @@ package=rust
 $(package)_version=1.16.0
 $(package)_download_path=https://static.rust-lang.org/dist
 $(package)_file_name_linux=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_file_name=rust-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
 $(package)_sha256_hash_linux=48621912c242753ba37cad5145df375eeba41c81079df46f93ffb4896542e8fd
-$(package)_sha256_hash=523cd248363afdc4e2c0e1f219607897b6925294a33154d7e67224addfd15eb0
 $(package)_file_name_darwin=rust-$($(package)_version)-x86_64-apple-darwin.tar.gz
 $(package)_sha256_hash_darwin=2d08259ee038d3a2c77a93f1a31fc59e7a1d6d1bbfcba3dba3c8213b2e5d1926
+$(package)_file_name_mingw32=rust-$($(package)_version)-x86_64-pc-windows-gnu.tar.gz
+$(package)_sha256_hash_mingw32=523cd248363afdc4e2c0e1f219607897b6925294a33154d7e67224addfd15eb0
 
 define $(package)_stage_cmds
   ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native --disable-ldconfig


### PR DESCRIPTION
1. Fixes [cross-compilation from linux to windows](https://github.com/BTCPrivate/BitcoinPrivate/issues/69) 

2. Adds detailed instructions for windows build from windows 10


Everything compiled on my end just fine by following this instructions. There might be other dependencies that i have installed and missed on the readme