### PR TITLE
base58prefixes modified for btcp

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -97,17 +97,17 @@ public:
         // TODO: setup a DNSSeed
         //vSeeds.push_back(CDNSSeedData("btcprivate.org", "dnsseed.btcprivate.org"));
 
-        // guarantees the first 2 characters, when base58 encoded, are "t1"
-        base58Prefixes[PUBKEY_ADDRESS]     = {0x1C,0xB8};
-        // guarantees the first 2 characters, when base58 encoded, are "t3"
-        base58Prefixes[SCRIPT_ADDRESS]     = {0x1C,0xBD};
+        // guarantees the first 2 characters, when base58 encoded, are "b1"
+        base58Prefixes[PUBKEY_ADDRESS]     = {0x13,0x25};
+        // guarantees the first 2 characters, when base58 encoded, are "bx"
+        base58Prefixes[SCRIPT_ADDRESS]     = {0x13,0xAF};
         // the first character, when base58 encoded, is "5" or "K" or "L" (as in Bitcoin)
         base58Prefixes[SECRET_KEY]         = {0x80};
         // do not rely on these BIP32 prefixes; they are not specified and may change
         base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x88,0xB2,0x1E};
         base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x88,0xAD,0xE4};
-        // guarantees the first 2 characters, when base58 encoded, are "zc"
-        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0x9A};
+        // guarantees the first 2 characters, when base58 encoded, are "zk"
+        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0xA8};
         // guarantees the first 2 characters, when base58 encoded, are "SK"
         base58Prefixes[ZCSPENDING_KEY]     = {0xAB,0x36};
 
@@ -230,17 +230,17 @@ public:
         // TODO: setup a DNSSeed
         //vSeeds.push_back(CDNSSeedData("btcprivate.org", "dnsseed.testnet.btcprivate.org"));
 
-        // guarantees the first 2 characters, when base58 encoded, are "tm"
-        base58Prefixes[PUBKEY_ADDRESS]     = {0x1D,0x25};
-        // guarantees the first 2 characters, when base58 encoded, are "t2"
-        base58Prefixes[SCRIPT_ADDRESS]     = {0x1C,0xBA};
+        // guarantees the first 2 characters, when base58 encoded, are "n1"
+        base58Prefixes[PUBKEY_ADDRESS]     = {0x19,0x58};
+        // guarantees the first 2 characters, when base58 encoded, are "nx"
+        base58Prefixes[SCRIPT_ADDRESS]     = {0x19,0xE0};
         // the first character, when base58 encoded, is "9" or "c" (as in Bitcoin)
         base58Prefixes[SECRET_KEY]         = {0xEF};
         // do not rely on these BIP32 prefixes; they are not specified and may change
         base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x35,0x87,0xCF};
         base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x35,0x83,0x94};
-        // guarantees the first 2 characters, when base58 encoded, are "zt"
-        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0xB6};
+        // guarantees the first 2 characters, when base58 encoded, are "zz"
+        base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0xC0};
         // guarantees the first 2 characters, when base58 encoded, are "ST"
         base58Prefixes[ZCSPENDING_KEY]     = {0xAC,0x08};
 


### PR DESCRIPTION
Proposed base58 prefixes -

**mainnet prefixes -**
b1 is 0x13 0x25 - mainnet pubkey [transparent] ("be one")
bx is 0x13 0xAF - i like this one for script / multisig ("be 'x'")

zk is 0x16 0xA8

**testnet prefixes -** 

n1 is 0x19 0x58 - testnet pubkey [transparent]
nx is 0x19 0xE0 - script / multisig

zz is 0x16 0xC0

I dont think we need to change 'SK', the spending key prefix, but we can.

Used https://github.com/ch4ot1c/base58prefixes for testing against 'golden' values in https://github.com/FiloSottile/zcash-mini/blob/9330b716ef4c2f2f7dd808d1edbd267f56e65bb3/zcash/address_test.go