### PR TITLE
xprv/xpub -> 1prv/1pub (BIP32 base58 prefixes)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -103,9 +103,10 @@ public:
         base58Prefixes[SCRIPT_ADDRESS]     = {0x1C,0xBD};
         // the first character, when base58 encoded, is "5" or "K" or "L" (as in Bitcoin)
         base58Prefixes[SECRET_KEY]         = {0x80};
-        // do not rely on these BIP32 prefixes; they are not specified and may change
-        base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x88,0xB2,0x1E};
-        base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x88,0xAD,0xE4};
+        // These prefixes technically don't adhere to BIP32, but are distinctly specified to avoid mixups.
+        // When base58 encoded, they are "1pub" and "1prv" for Bitcoin Private.
+        base58Prefixes[EXT_PUBLIC_KEY]     = {0x00,0x11,0x2C,0x54};
+        base58Prefixes[EXT_SECRET_KEY]     = {0x00,0x11,0x28,0x1A};
         // guarantees the first 2 characters, when base58 encoded, are "zc"
         base58Prefixes[ZCPAYMENT_ADDRRESS] = {0x16,0x9A};
         // guarantees the first 2 characters, when base58 encoded, are "SK"
@@ -236,7 +237,8 @@ public:
         base58Prefixes[SCRIPT_ADDRESS]     = {0x1C,0xBA};
         // the first character, when base58 encoded, is "9" or "c" (as in Bitcoin)
         base58Prefixes[SECRET_KEY]         = {0xEF};
-        // do not rely on these BIP32 prefixes; they are not specified and may change
+        // These prefixes adhere to BIP32.
+        // When base58 encoded, they are "tpub" and "tprv" for Bitcoin Private (as in Bitcoin).
         base58Prefixes[EXT_PUBLIC_KEY]     = {0x04,0x35,0x87,0xCF};
         base58Prefixes[EXT_SECRET_KEY]     = {0x04,0x35,0x83,0x94};
         // guarantees the first 2 characters, when base58 encoded, are "zt"


### PR DESCRIPTION
### New prefixes for "BIP32"
(Technically this breaks BIP32 but barely. We don't want anyone mixing up addresses of different chains.)

`1pub`:
`{0x00,0x11,0x2C,0x54}`

`1prv`:
`{0x00,0x11,0x28,0x1A}`

Tested using https://github.com/keis/base58

```
>>> import base58
>>> base58.b58encode(b'\x00\x11(\x1a)\xe2Q\x96\x05\xe8\xc08\x0f\x0c\x1eq\x88E\xc3\xae\xddY6\xc2x\xaf`\xb2\xc1+@\xafbTA\x1f0\xa1\xa5\x06Z\xbb\xa4+\xb50\x96%\x01pS?\x91W\x88|\xb4\x97\xc9\xf6\xf4v\x9e\xcc\xf5~\xfb\xb1[\x97\xca\xcfy\x85\xdc\x8fIW!\x16\xb0k')
'1prv9yTuSjwb95QZznV6epMWpb4Kpc2S8ZRaQuAf5B697YXtQD2tDmmJ5KvwJWVjtbVrdJ1WBKNnuodrpTKGfHfiPSEgrAxUjL5RP1gQwwT3fFx'
>>> base58.b58encode(b'\x00\x11,T\x9eG\x05\xfc\x99\x08\xb7\xad\xbf{\xfd\xf9\x86\xd9\x98\x01z\xdb\xa9\x97\xe6\xb9\x06oh\x10x\xdeEK^\xcb\xa6\xb6+.\xebG\xe3\xfb^\x83\x96\xdd\x14\x15\xa9\xb6C\x0eB\xd1b\xa4\xb3\xc6\xbb\x86\x88B\x81\xd2\xfe>\x93\x97\xca\xcfy\x85\xdc\x8fIW!\x16\xb0k')
'1pub9yTuSjwb95QZznV6epMWpb4Kpc2S8ZRaQuAf5B697YXtQD2tDmmJ5KvwJWVjtbVrdJ1WBKNnuodrpTKGfHfiPSEgrAxUjL5RP1gQwwT3fFx'
```

Appendix:  
https://simple.wikipedia.org/wiki/ASCII  
https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
