### PR TITLE
Testnet prefix for p2pkh is now always n1

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -231,7 +231,7 @@ public:
         //vSeeds.push_back(CDNSSeedData("btcprivate.org", "dnsseed.testnet.btcprivate.org"));
 
         // guarantees the first 2 characters, when base58 encoded, are "n1"
-        base58Prefixes[PUBKEY_ADDRESS]     = {0x19,0x58};
+        base58Prefixes[PUBKEY_ADDRESS]     = {0x19,0x57};
         // guarantees the first 2 characters, when base58 encoded, are "nx"
         base58Prefixes[SCRIPT_ADDRESS]     = {0x19,0xE0};
         // the first character, when base58 encoded, is "9" or "c" (as in Bitcoin)


### PR DESCRIPTION
Fix for testnet prefix