### PR TITLE
Added Mac-specific fix to account size_t ambiguity errors.

### DIFF
--- a/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
+++ b/src/wallet/asyncrpcoperation_shieldcoinbase.cpp
@@ -317,8 +317,13 @@ UniValue AsyncRPCOperation_shieldcoinbase::perform_joinsplit(ShieldCoinbaseJSInf
             {info.vjsin[0], info.vjsin[1]};
     boost::array<libzcash::JSOutput, ZC_NUM_JS_OUTPUTS> outputs
             {info.vjsout[0], info.vjsout[1]};
+    #ifdef __LP64__ // required to build on MacOS due to size_t ambiguity errors
+    boost::array<uint64_t, ZC_NUM_JS_INPUTS> inputMap;
+    boost::array<uint64_t, ZC_NUM_JS_OUTPUTS> outputMap;
+    #else
     boost::array<size_t, ZC_NUM_JS_INPUTS> inputMap;
     boost::array<size_t, ZC_NUM_JS_OUTPUTS> outputMap;
+    #endif
     JSDescription jsdesc = JSDescription::Randomized(
             *pzcashParams,
             joinSplitPubKey_,


### PR DESCRIPTION
The addition of asyncrpcoperation_shieldcoinbase.cpp re-introduced a Mac-specific compiler incompatibility (size_t ambiguity errors); to solve, the same pre-existing compile-time fix present elsewhere (asyncrpcoperation_sendmany.cpp) was applied to asyncrpcoperation_shieldcoinbase.cpp, making this change a relatively safe one.