### PR TITLE
Calculate network difficulty based on legacy powLimit value

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -41,13 +41,14 @@ double GetDifficultyINTERNAL(const CBlockIndex* blockindex, bool networkDifficul
         bits = blockindex->nBits;
     }
 
-    uint32_t powLimit =
-        UintToArith256(Params().GetConsensus().powLimit).GetCompact();
+	// instead of using powLimit, network difficulty is calculated using a legacy powLimit value to maintain comparability with the network difficulty of other Equihash-based coins for mining profitability calculations.
+    uint32_t powLimitLegacy =
+        UintToArith256(uint256S("0007ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")).GetCompact();
     int nShift = (bits >> 24) & 0xff;
-    int nShiftAmount = (powLimit >> 24) & 0xff;
+    int nShiftAmount = (powLimitLegacy >> 24) & 0xff;
 
     double dDiff =
-        (double)(powLimit & 0x00ffffff) /
+        (double)(powLimitLegacy & 0x00ffffff) /
         (double)(bits & 0x00ffffff);
 
     while (nShift < nShiftAmount)
@@ -61,6 +62,9 @@ double GetDifficultyINTERNAL(const CBlockIndex* blockindex, bool networkDifficul
         nShift--;
     }
 
+	// for compatibility purposes, the floor of 1.0 is maintained.
+	if (dDiff < 1) dDiff = 1.0;
+	
     return dDiff;
 }
 


### PR DESCRIPTION
With the increased powLimit value, the network difficulty values calculated are hundreds of times larger than typically expected for Equihash-based tokens; this may be problematic within the context of pre-existing mining profitability calculators. While the pow targets for mainnet at the moment are well below the current and legacy powLimit values, reverting the powLimit to the legacy value causes an assertion failure while checking the bits values of at least one previous block after the fork- so the calculation for displayed network difficulty is changed to use the legacy powLimit value so as to maintain comparability with the network difficulty values of other Equihash-based coins. A floor of 1.0 is also implemented to avoid potential compatibility issues with mining profitability calculators as well.