### PR TITLE
Enable spending Segwit outputs

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -71,6 +71,22 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
         return true;
     }
 
+    int witnessversion;
+    std::vector<unsigned char> witnessprogram;
+    if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
+        if (witnessversion == 0 && witnessprogram.size() == 20) {
+            typeRet = TX_WITNESS_V0_KEYHASH;
+            vSolutionsRet.push_back(witnessprogram);
+            return true;
+        }
+        if (witnessversion == 0 && witnessprogram.size() == 32) {
+            typeRet = TX_WITNESS_V0_SCRIPTHASH;
+            vSolutionsRet.push_back(witnessprogram);
+            return true;
+        }
+        return false;
+    }
+
     // Scan templates
     const CScript& script1 = scriptPubKey;
     BOOST_FOREACH(const PAIRTYPE(txnouttype, CScript)& tplate, mTemplates)
@@ -172,12 +188,14 @@ int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned c
     case TX_PUBKEY:
         return 1;
     case TX_PUBKEYHASH:
+    case TX_WITNESS_V0_KEYHASH:
         return 2;
     case TX_MULTISIG:
         if (vSolutions.size() < 1 || vSolutions[0].size() < 1)
             return -1;
         return vSolutions[0][0] + 1;
     case TX_SCRIPTHASH:
+    case TX_WITNESS_V0_SCRIPTHASH:
         return 1; // doesn't include args needed by the script
     }
     return -1;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -39,7 +39,8 @@ extern unsigned nMaxDatacarrierBytes;
 
 static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH |
     SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
-    SCRIPT_VERIFY_FORKID;
+    SCRIPT_VERIFY_FORKID |
+    SCRIPT_VERIFY_WITNESS;
 
 /**
  * Standard script verification flags that standard transactions will comply


### PR DESCRIPTION
Previously, transactions spending Segwit outputs were only accepted if they were already included in a block.
With this patch, new Segwit transactions are accepted and relayed.