### PR TITLE
Made value of CLIENT_VERSION_REVISION consistent, even in non-used code.

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -17,7 +17,7 @@
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 1
 #define CLIENT_VERSION_MINOR 0
-#define CLIENT_VERSION_REVISION 11
+#define CLIENT_VERSION_REVISION 12
 #define CLIENT_VERSION_BUILD 50
 
 //! Set to true for release, false for prerelease or test build


### PR DESCRIPTION
Made value of CLIENT_VERSION_REVISION in clientversion.h (though unused in current build process) the same as value of CLIENT_VERSION_REVISION in configure.ac (12) for the sake of consistency.