### PR TITLE
Update license year 2019

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018 The Bitcoin Private developers
+Copyright (c) 2017-2019 The Bitcoin Private developers
 Copyright (c) 2016-2017 The Zclassic developers
 Copyright (c) 2016-2017 The Zcash developers
 Copyright (c) 2009-2017 The Bitcoin Core developers


### PR DESCRIPTION
### Fix license of use, 
update 2019; 
Format ISO 8869-1;
----------------------------------------------------------------------------------------------------------------------
in Memoriam Guto Schiavon 
![guto-schiavon_bitcoin](https://user-images.githubusercontent.com/7637553/50562143-a7506f80-0cf8-11e9-9e58-bed4565c4715.jpg)
R.I.P pioneer and friend. 

#ripGUTO